### PR TITLE
Allow collection size constraint

### DIFF
--- a/jquery.sfprototypeman.js
+++ b/jquery.sfprototypeman.js
@@ -42,7 +42,7 @@
 	SfPrototypeContainer = function(container, config) {
 		this._container = container;
 		this._config = config;
-        this._fieldConfig = {}
+        this._fieldConfig = {};
 
 		if (!this._container.jquery || this._container.length !== 1) {
 			throw "Container has to be _one_ jQuery extended element";
@@ -64,20 +64,20 @@
 		},
 
 		applySizeConstraints: function() {
-            var data = this._container.data();
-            if (data.constrainedCollectionMinSize) {
-                this._fieldConfig.minSize = data.constrainedCollectionMinSize;
-            }
-            if (data.constrainedCollectionMaxSize) {
-                this._fieldConfig.maxSize = data.constrainedCollectionMaxSize;
-            }
+			var data = this._container.data(),
+				counter = this._getExisting().length;
+			if (data.constrainedCollectionMinSize) {
+				this._fieldConfig.minSize = data.constrainedCollectionMinSize;
+			}
+			if (data.constrainedCollectionMaxSize) {
+				this._fieldConfig.maxSize = data.constrainedCollectionMaxSize;
+			}
 
-            if (this._fieldConfig.minSize){
-                var counter = this._getExisting().length;
-                for (var i = counter, l= this._fieldConfig.minSize; i<l; i++){
-                    this.addField();
-                }
-            }
+			if (this._fieldConfig.minSize){
+				for (var i = counter, l= this._fieldConfig.minSize; i<l; i++){
+					this.addField();
+				}
+			}
         },
 
 		/**
@@ -108,23 +108,23 @@
 		 */
 		addField: function() {
 			var counter = this._getExisting().length,
-                    	maxSize = this._fieldConfig.maxSize,
-                	 mustAppend = true;
-            
-			if (typeof maxSize != 'undefined') {
+				maxSize = this._fieldConfig.maxSize,
+				mustAppend = true;
+
+			if (typeof maxSize != "undefined") {
 				if (counter >= maxSize){
 					mustAppend = false;
 					this._container.trigger("prototype.maxsize-already-reached", [this]);
 				}
 			}
-	
+
 			if (mustAppend){
 				var newElement = this._createField(counter);
 				newElement.appendTo(this._container);
-				
+
 				this._container.trigger("prototype.added", [this]);
-				
-				if (maxSize && counter - maxSize == 1){
+
+				if (maxSize && counter - maxSize === 1){
 					this._container.trigger("prototype.maxsize-reached", [this]);
 				}
 			}


### PR DESCRIPTION
Hello,

There is a contribution that aims to add size limitations on the field collection (I needed that for a project I'm working on).
This is my first contribution \o/
So if you're interested in, please, comment on whatever you want:
- coding style
- options/event naming strategy
- what about a global configuration that could be override at field level (only field level is implemented right now)

Below, my commit description:

Allow to define collection size constraint via data attribute on the field
- data-constrained-collection-min-size
- data-constrained-collection-max-size

if min size is defined, then, at initialization, at least [min size items] are created (if not already existing)
if max size is defined, it is not possible to add more items when max size is reached

New events triggered on this._container:
- prototype.maxsize-reached (when the last permitted item is added)
- prototype.maxsize-already-reached (when addField is called but the maximum size has already been reached)
